### PR TITLE
Fix #2

### DIFF
--- a/app/Correios/CorreiosScraper.php
+++ b/app/Correios/CorreiosScraper.php
@@ -64,7 +64,7 @@ class CorreiosScraper
                 if ($columnTagName === 'th') {
                     $headers[] = $columnText;
                 } else if ($columnTagName === 'td') {
-                    $address[ $headers[$columnIndex] ] = $columnText;
+                    $address[ $headers[$columnIndex] ] = trim($columnText, chr(0xC2).chr(0xA0));
                 }
             }
 


### PR DESCRIPTION
UTF encoda a entidade html de espaços (&nbsp;) como `0xC2 0xA0`, por isso é precisso passar para a função trim